### PR TITLE
Add practical example to explainer.

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ callers since it's in a local scope.  This assumes that TT's [first-come-first-s
 provisioning, letting only authorized callers access the sensitive
 operation.
 
-``js
+```js
 const { Array, TypeError } = globalThis;
 const { createPolicy } = trustedTypes;
 const { isTemplateObject } = Array;

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Without `isArrayTemplate`, this can be bypassed:
 ```js
 // A naive, but non-malicious function.
 function f(x) {
-  // People trust trustedHTMTagFunction.
+  // People trust trustedHTMLTagFunction.
   // Our HTML is trustworthy because <bad argument> so we'll just
   // piggyback off that by using a value that looks like a template object.
   // What could possibly go wrong?

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ called with a template string bundle.
 
 * [Use cases & Prior Discussions](#use-cases--prior-discussions)
   + [Distinguishing strings from a trusted developer from strings that may be attacker controlled](#distinguishing-strings-from-a-trusted-developer-from-strings-that-may-be-attacker-controlled)
+* [An example](#an-example)
 * [What this is not](#what-this-is-not)
 * [Possible Spec Language](#possible-spec-language)
 * [Polyfill](#polyfill)
@@ -60,6 +61,105 @@ console.log(Array.isTemplateObject(x));
 Many other security assumptions break if an attacker can execute arbitrary code,
 so this check is still useful.
 
+## An Example
+
+Here's an example of how `isTemplateObject` lets a tag function wisely
+use a sensitive operation, namely *[Create a Trusted Type][]*.  The
+sensitive operation is not directly accessible to the tag function's
+callers since it's in a local scope.  This assumes that TT's [first-come-first-serve name restrictions][TT-block] solve
+provisioning, letting only authorized callers access the sensitive
+operation.
+
+``js
+const { Array, TypeError } = globalThis;
+const { createPolicy } = trustedTypes;
+const { isTemplateObject } = Array;
+const { error: consoleErr } = console;
+
+/**
+ * A tag function that produces *TrustedHTML* or null if the
+ * policy name "trustedHTMTagFunction" is not available.
+ */
+export trustedHTML = (() => {
+  // We use TrustedType's first-come-first-serve policy name restrictions
+  // to provision this scope with sensitiveOperation.
+  const policyName = 'trustedHTMLTagFunction';
+  let policy;
+  try {
+    policy = createPolicy(
+        'trustedHTMLTagFunction',
+        { createHTML(s) { return s } }
+    );
+  } catch (ex) {
+    consoleErr(`${policyName} is not an allowed trustedTypes policy name`);
+    return null;
+  }
+
+  // This is the sensitive operation.
+  const { createHTML } = policy;
+
+  // This tag function uses isTemplateObject to reject strings that
+  // do not appear in user code in the same realm.
+  //
+  // With a reliable isTemplateObject check, the attack surface is
+  // <= |set of template applications in trusted code|.
+  //
+  // That set is finite.
+  //
+  // Without a reliable isTemplateObject check, the attack surface is
+  // <= |set of attacker controlled strings|.  That is, in practice,
+  // unbounded.
+  //
+  // This assumes no attacker has eval.
+  const trustedHTMLTagFunction = (strings) => {
+    if (isTemplateObject(strings) && strings instanceof Array) {
+      return createHTML(strings.raw[0]);
+    }
+    throw new TypeError("Expected template object");
+  };
+
+  // With the check it's safe to export this tag function that closes
+  // over a sensitive operation to anyone.
+  return trustedHTMLTagFunction;
+})()
+```
+
+Without `isArrayTemplate`, this can be bypassed:
+
+```js
+// A naive, but non-malicious function.
+function f(x) {
+  // People trust trustedHTMTagFunction.
+  // Our HTML is trustworthy because <bad argument> so we'll just
+  // piggyback off that by using a value that looks like a template object.
+  // What could possibly go wrong?
+  const s = dodgyMarkdownToHTMLConverter(x);
+  const pseudoTemplateObject = [s];
+  pseudoTemplateObject.raw = Object.freeze([s]);
+  return trustedHTML(Object.freeze(pseudoTemplateObject));
+}
+
+// An attacker controlled string reaches f().
+const payload = '<img onerror=alert(document.origin) src=x>';
+console.log(`f(${ JSON.stringify(payload) }) = ${ f(payload) }`);
+```
+
+The threat model here involves three actors:
+*  A team of *first-party developers* (in conjunction with security
+   specialists) decides to trust the tag function.
+*  A malicious *attacker* controls a string in the variable `payload`.
+*  Non-malicious but confusable third-party library tries to provide a
+   higher level of service by forging a template object.
+   It assumes its clients are comfortable with trusting
+   `dodgyMarkdownToHTMLConverter` to produce HTML for the current origin.
+
+We've addressed this threat model when the first-party developers can
+be less tolerant of risk than the most risk tolerant third party
+dependency w.r.t. HTML injection.
+
+This simple implementation doesn't deal with interpolations.
+A more thorough implementation could do [contextual autoescaping][].
+
 ## What this is not
 
 This is not an attempt to determine whether the current function was called as a template literal.
@@ -88,3 +188,7 @@ which would be added under
 
 If the [literals proposal](https://github.com/mikewest/tc39-proposal-literals) were to advance,
 this proposal would be unnecessary since they both cover the use cases from this document.
+
+[contextual autoescaping]: https://rawgit.com/mikesamuel/sanitized-jquery-templates/trunk/safetemplate.html
+[TT-block]: https://w3c.github.io/webappsec-trusted-types/dist/spec/#abstract-opdef-should-trusted-type-policy-creation-be-blocked-by-content-security-policy
+[Create a Trusted Type]: https://w3c.github.io/webappsec-trusted-types/dist/spec/#create-a-trusted-type-algorithm

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ const { error: consoleErr } = console;
 
 /**
  * A tag function that produces *TrustedHTML* or null if the
- * policy name "trustedHTMTagFunction" is not available.
+ * policy name "trustedHTMLTagFunction" is not available.
  */
 export trustedHTML = (() => {
   // We use TrustedType's first-come-first-serve policy name restrictions


### PR DESCRIPTION
Fix #12

This does not meet @gibson042's requirement:

> but does not demonstrate any use case in which a potential attacker
> has the ability to provide arguments to a sensitiveOperation
> function

but as explained on the issue, I think that's the wrong standard.

If we can assume some mechanism to solve *provisioning*, getting
a sensitiveOperation to a tag function without providing it to
all the tag function's potential callers, then an unbypassable
isTemplateObject check can provide value.

Trusted Types has provisioning machinery, so the example uses that.